### PR TITLE
Comment uses body, not selftext

### DIFF
--- a/app.js
+++ b/app.js
@@ -82,7 +82,7 @@ comments.on("item", comment => {
     let reply = "";
 
     // Check if the comment text contains the scope command
-    if (includesWord("scope();", comment.selftext)) {
+    if (includesWord("scope();", comment.body)) {
         reply = response.scope;
     }
 


### PR DESCRIPTION
I kinda feel like using selftext like Submission would have been more consistent, but I guess body is accurate as well